### PR TITLE
Fix: bundlerバージョンの変更（herokuのbundlerにバージョンを合わせるため）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
     pg (1.4.4)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -150,6 +152,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
# 概要
herokuへのデプロイ時にbundlerのバージョンの差異をなくすために、
`bundle lock --add-platform x86_64-linux`
をコマンドで実行してgemfile.lockの内容を変更した。
# 確認事項
ローカルのアプリをbundlerのバージョンの変更
# 確認方法
gemfile.lockの差分を確認すれば良い
# 懸念点
11月28日からherokuの有料化が始まるので、一旦herokuのアプリの方は削除するかもしれない。