### PR TITLE
Update: ジェネレートコマンドでルートとヘルパーとテストを生成しないように設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,11 @@ module FlowerMap
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.generators do |g|
+      g.skip_routes true
+      g.helper false
+      g.test_framework false
+    end
   end
 end


### PR DESCRIPTION
# 概要
rails g コマンドでルートとヘルパーとテストが生成されないように設定した。
# 確認事項
ルートとヘルパーとテストが生成されないか確認。
# 確認方法
'rails g model xxxxxx'
'rails g controller xxxxxx'
で生成されるか確認する。
[![Image from Gyazo](https://i.gyazo.com/0afa85b7e93171e4a983c21bde3b7c06.png)](https://gyazo.com/0afa85b7e93171e4a983c21bde3b7c06)
[![Image from Gyazo](https://i.gyazo.com/c4d42c1674b9905f253083e1a029b694.png)](https://gyazo.com/c4d42c1674b9905f253083e1a029b694)
以上のように表記されていれば良い
# 懸念点
# 参考資料
