### PR TITLE
Add: バックエンドのルーティングを追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  namespace :api do
+    namespace :v1 do
+      resources :flowers do
+        get 'today_flower' to: 'today_flower#index'
+      end
+      post 'login', to: 'user_sessions#create'
+      delete 'logout', to: 'user_sessions#destroy'
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :flowers do
-        get 'today_flower' to: 'today_flower#index'
+        get 'today_flower', to: 'today_flower#index'
       end
       post 'login', to: 'user_sessions#create'
       delete 'logout', to: 'user_sessions#destroy'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end


### PR DESCRIPTION
# 概要
以下を実行しました。
- routes.rbにnamespace :apiとnamespace :v1の名前空間を定義する。その名前空間内にルーティングを作成する。
- resourcesを使って、flowerのcrudのルーティングを実装。
- postメソッドを使って、user_session#createのルーティングを作成する。
- deleteメソッドを使って、user_session#destroyのルーティングを作成する。
# 確認事項
- config/routes.rbにルートを定義されている。
# 確認方法
`http://localhost:3000/rails/info/routes`でルーティングを確認できる。
# 懸念点
OAuthは後に実装する。
# 参考資料
https://zenn.dev/yukihaga/articles/69a816962ef6b9#5.%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0%E3%81%AE%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3

https://qiita.com/morioka1206/items/6a33885aed483bf46373